### PR TITLE
Initial commit: Introduce `pizza bake` CLI command

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,17 @@
+name: Test and build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.20
+      - name: Build
+        run: make build
+      - name: Test
+        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore stuff from the builds that get generated.
+build/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,14 @@
+linters:
+  enable:
+    - errcheck
+    - goimports
+    - ineffassign
+    - misspell
+    - revive
+    - staticcheck
+    - unconvert
+    - unused
+    - vet
+
+run:
+  timeout: 5m

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: test build run
+
+all: lint test build
+
+lint:
+	docker run \
+		-t \
+		--rm \
+		-v ./:/app \
+		-w /app \
+		golangci/golangci-lint:v1.53.3 \
+		golangci-lint run -v
+
+test:
+	go test ./...
+
+build:
+	go build -o build/pizza main.go
+
+install: build
+	sudo mv build/pizza /usr/local/bin/
+
+run:
+	go run main.go
+
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,48 @@
-# 🚧👷 Pizza CLI 👷🚧
+# 🍕 Pizza CLI
 
 This CLI can be used for all things OpenSauced!
+
+```
+❯ pizza
+
+Usage:
+  pizza <command> <subcommand> [flags]
+
+Available Commands:
+  bake        Use a pizza-oven to source git commits into OpenSauced
+  completion  Generate the autocompletion script for the specified shell
+  help        Help about any command
+
+Flags:
+  -h, --help   help for pizza
+
+Use "pizza [command] --help" for more information about a command.
+```
+
+---
+
+### 🖥️ Local Development
+
+You'll need a few tools to get started:
+
+- The [Go toolchain](https://go.dev/doc/install)
+- [Docker](https://docs.docker.com/engine/install/) (for linting and other tooling)
+- Make
+
+To lint, run `make lint`. To run tests, run `make test`. To build, run `make build`.
+
+### 🏗️ Installation
+
+#### Manual build and install
+
+```
+make install
+```
+
+This is a convenience target for building and dropping the pizza CLI into
+`/usr/local/bin/` (which requires `sudo` permissions).
+Make sure you have that directory in your path: `export PATH="$PATH:/usr/local/bin"`.
+Otherwise, you can build it manually with `make build` and `mv build/pizza <somewhere-in-your-path>`.
+
+In the future, we will be dropping regular GitHub releases where you can easily
+download and install pre-built binaries.

--- a/cmd/bake/bake.go
+++ b/cmd/bake/bake.go
@@ -1,0 +1,92 @@
+// Package bake contains the bootstrapping and tooling for the pizza bake
+// cobra command
+package bake
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spf13/cobra"
+)
+
+// Options are the options for the pizza bake command including user
+// defined configurations
+type Options struct {
+	// Endpoint is the service endpoint to reach out to
+	Endpoint string
+
+	// URL is the git repo URL that will be sourced via 'pizza bake'
+	URL string
+}
+
+const bakeLongDesc string = `WARNING: Proof of concept feature.
+
+The bake command takes a URL to a git repository and uses a pizza-oven service
+to source those commits. These commits will then be used for insights on OpenSauced.`
+
+// NewBakeCommand returns a new cobra command for 'pizza bake'
+func NewBakeCommand() *cobra.Command {
+	opts := &Options{}
+
+	cmd := &cobra.Command{
+		Use:   "bake url [flags]",
+		Short: "Use a pizza-oven to source git commits into OpenSauced",
+		Long:  bakeLongDesc,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 1 {
+				return errors.New("only a single url can be ingested at a time")
+			}
+			if len(args) == 0 {
+				return errors.New("must specify the URL of a git repository")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.URL = args[0]
+			return run(opts)
+		},
+	}
+
+	// TODO - this will need to be a live service URL by default.
+	// For now, localhost is fine.
+	cmd.Flags().StringVarP(&opts.Endpoint, "endpoint", "e", "http://localhost:8080", "The endpoint to send requests to")
+
+	return cmd
+}
+
+type bakePostRequest struct {
+	URL string `json:"url"`
+}
+
+func run(opts *Options) error {
+	bodyPostReq := &bakePostRequest{
+		URL: opts.URL,
+	}
+
+	bodyPostJSON, err := json.Marshal(bodyPostReq)
+	if err != nil {
+		return err
+	}
+
+	responseBody := bytes.NewBuffer(bodyPostJSON)
+	resp, err := http.Post(fmt.Sprintf("%s/bake", opts.Endpoint), "application/json", responseBody)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Resp body: %v\n", string(body))
+	}
+
+	return nil
+}

--- a/cmd/bake/bake_test.go
+++ b/cmd/bake/bake_test.go
@@ -1,0 +1,47 @@
+package bake
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSendsPost(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *Options
+	}{
+		{
+			name: "Sends post request",
+			opts: &Options{
+				URL: "https://test.com",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Fail()
+				}
+
+				// Always return an ok status with a dummy body from the mock server
+				w.WriteHeader(http.StatusOK)
+				_, err := w.Write([]byte("body"))
+				if err != nil {
+					// Writing back to the client shouldn't fail
+					t.Fail()
+				}
+			}))
+			defer testServer.Close()
+
+			tt.opts.Endpoint = testServer.URL
+
+			err := run(tt.opts)
+			if err != nil {
+				t.Fail()
+			}
+		})
+	}
+}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -1,0 +1,26 @@
+// Package root initiates and bootstraps the pizza CLI root Cobra command
+package root
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/open-sauced/pizza-cli/cmd/bake"
+)
+
+// NewRootCommand bootstraps a new root cobra command for the pizza CLI
+func NewRootCommand() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:   "pizza <command> <subcommand> [flags]",
+		Short: "OpenSauced CLI",
+		Long:  `A command line utility for insights, metrics, and all things OpenSauced`,
+		RunE:  run,
+	}
+
+	cmd.AddCommand(bake.NewBakeCommand())
+
+	return cmd, nil
+}
+
+func run(cmd *cobra.Command, _ []string) error {
+	return cmd.Help()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,14 @@
+module github.com/open-sauced/pizza-cli
+
+go 1.20
+
+require (
+	github.com/spf13/cobra v1.7.0
+	github.com/spf13/pflag v1.0.5
+	golang.org/x/term v0.9.0
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	golang.org/x/sys v0.9.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+golang.org/x/sys v0.9.0 h1:KS/R3tvhPqvJvwcKfnBHJwwthS11LRhmM5D59eEXa0s=
+golang.org/x/sys v0.9.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.9.0 h1:GRRCnKYhdQrD8kfRAdQ6Zcw1P0OcELxGLKJvtjVMZ28=
+golang.org/x/term v0.9.0/go.mod h1:M6DEAAIenWoTxdKrOltXcmDY3rSplQUkrvaDU5FcQyo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"log"
+
+	"github.com/open-sauced/pizza-cli/cmd/root"
+	"github.com/open-sauced/pizza-cli/pkg/utils"
+)
+
+func main() {
+	rootCmd, err := root.NewRootCommand()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	utils.SetupRootCommand(rootCmd)
+
+	err = rootCmd.Execute()
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/utils/help.go
+++ b/pkg/utils/help.go
@@ -1,0 +1,4 @@
+package utils
+
+var helpTemplate = `
+{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`

--- a/pkg/utils/root.go
+++ b/pkg/utils/root.go
@@ -1,0 +1,12 @@
+package utils
+
+import "github.com/spf13/cobra"
+
+// SetupRootCommand is a convinence utility for applying templates and nice
+// user experience pieces to the root cobra command
+func SetupRootCommand(rootCmd *cobra.Command) {
+	cobra.AddTemplateFunc("wrappedFlagUsages", wrappedFlagUsages)
+
+	rootCmd.SetUsageTemplate(usageTemplate)
+	rootCmd.SetHelpTemplate(helpTemplate)
+}

--- a/pkg/utils/usage.go
+++ b/pkg/utils/usage.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"os"
+
+	"github.com/spf13/pflag"
+	"golang.org/x/term"
+)
+
+// Identical to the default cobra usage template,
+// but utilizes wrappedFlagUsages to ensure flag usages don't wrap around
+var usageTemplate = `Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{wrappedFlagUsages .LocalFlags | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{wrappedFlagUsages .InheritedFlags | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`
+
+// Uses the users terminal size or width of 80 if cannot determine users width
+func wrappedFlagUsages(cmd *pflag.FlagSet) string {
+	fd := int(os.Stdout.Fd())
+	width := 80
+
+	// Get the terminal width and dynamically set
+	termWidth, _, err := term.GetSize(fd)
+	if err == nil {
+		width = termWidth
+	}
+
+	return cmd.FlagUsagesWrapped(width - 1)
+}


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR introduces the `pizza` CLI and sets up the Cobra Go CLI structure for other commands (eventually).

```
❯ pizza

Usage:
  pizza <command> <subcommand> [flags]

Available Commands:
  bake        Use a pizza-oven to source git commits into OpenSauced
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command

Flags:
  -h, --help   help for pizza

Use "pizza [command] --help" for more information about a command.

```

Right now, the `pizza bake` command defaults to using `localhost` but there's a `-e / --endpoint` flag that can be used for testing an eventual service as well.

```
❯ pizza bake --help

Usage:
  pizza bake url [flags]

Flags:
  -e, --endpoint string   The endpoint to send requests to (default "http://localhost:8080")
  -h, --help              help for bake
```

After setting up a pizza-oven service locally: https://github.com/open-sauced/pizza, I opened a port on my machine to the service at `localhost:8080`:

```
❯ pizza bake https://github.com/jpmcb/dotfiles
```

Providing a bogus git URL fails:
```
❯ pizza bake https://github.com/jpmcb/doesnt-exist
Resp body: Could not process input
```

## Related Tickets & Documents

Related to https://github.com/open-sauced/pizza/issues/1 which lays out a design for a service that this CLI can interact with.

## Mobile & Desktop Screenshots/Recordings

N/a

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [x] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

N/a

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/ftSalHoEma5EtzulYE/giphy.gif)

<!-- note: PRs with deleted sections will be marked invalid -->

