### PR TITLE
feat: cli auth

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -1,0 +1,191 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"path"
+	"time"
+
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+)
+
+const (
+	codeChallengeLength = 87
+	supabaseID          = "ibcwmlhcimymasokhgvn"
+	supabasePublicKey   = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlhdCI6MTYyOTkzMDc3OCwiZXhwIjoxOTQ1NTA2Nzc4fQ.zcdbd7kDhk7iNSMo8SjsTaXi0wlLNNQcSZkzZ84NUDg"
+	authCallbackAddr    = "localhost:3000"
+	sessionFileName     = "session.json"
+)
+
+//go:embed success.html
+var successHtml string
+
+func NewLoginCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "Log into the CLI application via GitHub",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run()
+		},
+	}
+
+	return cmd
+}
+
+func run() error {
+	codeVerifier, codeChallenge, err := pkce(codeChallengeLength)
+	if err != nil {
+		return fmt.Errorf("PKCE error: %v", err)
+	}
+
+	supabaseAuthURL := fmt.Sprintf("https://%s.supabase.co/auth/v1/authorize", supabaseID)
+	queryParams := url.Values{
+		"provider":              {"github"},
+		"code_challenge":        {codeChallenge},
+		"code_challenge_method": {"S256"},
+		"redirect_to":           {"http://" + authCallbackAddr + "/"},
+	}
+
+	authenticationURL := supabaseAuthURL + "?" + queryParams.Encode()
+
+	server := &http.Server{Addr: authCallbackAddr}
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		defer shutdown(server)
+
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			http.Error(w, "Error: auth-code query param not found", http.StatusBadRequest)
+			return
+		}
+
+		sessionData, err := getSession(code, codeVerifier)
+		if err != nil {
+			http.Error(w, "Error: Access token exchange failed", http.StatusInternalServerError)
+			return
+		}
+
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			fmt.Println("Error getting home directory:", err)
+			return
+		}
+
+		dirName := path.Join(homeDir, ".pizza")
+		if err := os.MkdirAll(dirName, os.ModePerm); err != nil {
+			http.Error(w, ".pizza directory couldn't be created", http.StatusInternalServerError)
+			return
+		}
+
+		jsonData, err := json.Marshal(sessionData)
+		if err != nil {
+			http.Error(w, "Error marshaling session data", http.StatusInternalServerError)
+			return
+		}
+
+		filePath := path.Join(dirName, sessionFileName)
+		if err := os.WriteFile(filePath, jsonData, 0o600); err != nil {
+			http.Error(w, "Error writing to file", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write([]byte(successHtml))
+
+		username := sessionData["user"].(map[string]interface{})["user_metadata"].(map[string]interface{})["user_name"].(string)
+		fmt.Println("🎉 Login successful 🎉")
+		fmt.Println("Welcome aboard", username, "🍕")
+
+	})
+
+	err = browser.OpenURL(authenticationURL)
+	if err != nil {
+		fmt.Println("Failed to open the browser 🤦‍♂️")
+		fmt.Println("Navigate to the following URL to begin authentication:")
+		fmt.Println(authenticationURL)
+	}
+
+	errCh := make(chan error)
+	go func() {
+		errCh <- server.ListenAndServe()
+	}()
+
+	interruptCh := make(chan os.Signal, 1)
+	signal.Notify(interruptCh, os.Interrupt)
+
+	select {
+	case err := <-errCh:
+		if err != nil && err != http.ErrServerClosed {
+			return err
+		}
+	case <-time.After(60 * time.Second):
+		shutdown(server)
+		return errors.New("authentication timeout")
+	case <-interruptCh:
+		fmt.Println("\nAuthentication interrupted❗️")
+		shutdown(server)
+		os.Exit(0)
+	}
+	return nil
+}
+
+func getSession(authCode, codeVerifier string) (map[string]interface{}, error) {
+	url := fmt.Sprintf("https://%s.supabase.co/auth/v1/token?grant_type=pkce", supabaseID)
+
+	payload := map[string]string{
+		"auth_code":     authCode,
+		"code_verifier": codeVerifier,
+	}
+
+	jsonPayload, _ := json.Marshal(payload)
+
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(jsonPayload))
+	req.Header.Set("Content-Type", "application/json;charset=UTF-8")
+	req.Header.Set("ApiKey", supabasePublicKey)
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status: %s", res.Status)
+	}
+
+	var responseData map[string]interface{}
+	if err := json.NewDecoder(res.Body).Decode(&responseData); err != nil {
+		return nil, err
+	}
+
+	return responseData, nil
+}
+
+func pkce(length int) (verifier, challenge string, err error) {
+	p := make([]byte, length)
+	if _, err := io.ReadFull(rand.Reader, p); err != nil {
+		return "", "", err
+	}
+	verifier = base64.RawURLEncoding.EncodeToString(p)
+	b := sha256.Sum256([]byte(verifier))
+	challenge = base64.RawURLEncoding.EncodeToString(b[:])
+	return verifier, challenge, nil
+}
+
+func shutdown(server *http.Server) {
+	go server.Shutdown(context.Background())
+}

--- a/cmd/auth/success.html
+++ b/cmd/auth/success.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>OpenSauced Pizza-CLI</title>
+    <style>
+      body {
+        margin: 0;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 100vh;
+        background: linear-gradient(135deg, #ff9900, #ff5500);
+        font-family: Arial, sans-serif;
+        position: relative;
+      }
+      .container {
+        text-align: center;
+        padding: 20px;
+        background-color: rgba(255, 255, 255, 0.9);
+        border-radius: 10px;
+        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2), 0 5px 15px rgba(0, 0, 0, 0.3);
+        transition: transform 0.3s;
+      }
+      .container:hover {
+        transform: scale(1.05);
+      }
+      .pizza-icon {
+        font-size: 80px;
+        margin-bottom: 20px;
+        text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
+      }
+      .title {
+        color: #ff5500;
+        font-size: 32px;
+        font-weight: bold;
+        margin: 0;
+        margin-bottom: 10px;
+      }
+      .message {
+        color: #555;
+        font-size: 20px;
+      }
+      .opensauced-logo {
+        display: flex;
+        align-items: center;
+        position: absolute;
+        top: 20px;
+        left: 20px;
+        color: #fff;
+        font-size: 28px;
+        font-weight: bold;
+      }
+      .logo-image {
+        width: 60px;
+        height: 60px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="pizza-icon">🍕</div>
+      <h1 class="title">Authentication Successful</h1>
+      <p class="message" id="counter">
+        This window will be closed in 3 seconds
+      </p>
+    </div>
+    <div class="opensauced-logo">
+      <img
+        src="https://raw.githubusercontent.com/open-sauced/assets/main/logos/slice-White.png"
+        alt="OpenSauced Logo"
+        class="logo-image"
+      />
+      <div class="logo-text">OpenSauced</div>
+    </div>
+    <script>
+      const counterElement = document.getElementById("counter");
+      let seconds = 3;
+      let interval = setInterval(() => {
+        if (seconds <= 1) {
+          clearInterval(interval);
+          window.close();
+        }
+        counterElement.innerHTML = `This window will be closed in ${--seconds} second${
+          seconds > 1 ? "s" : ""
+        }`;
+      }, 1000);
+    </script>
+  </body>
+</html>

--- a/cmd/bake/bake.go
+++ b/cmd/bake/bake.go
@@ -78,8 +78,8 @@ func run(opts *Options) error {
 		return err
 	}
 
-	responseBody := bytes.NewBuffer(bodyPostJSON)
-	resp, err := http.Post(fmt.Sprintf("%s/bake", opts.Endpoint), "application/json", responseBody)
+	requestBody := bytes.NewBuffer(bodyPostJSON)
+	resp, err := http.Post(fmt.Sprintf("%s/bake", opts.Endpoint), "application/json", requestBody)
 	if err != nil {
 		return err
 	}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -4,6 +4,7 @@ package root
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/open-sauced/pizza-cli/cmd/auth"
 	"github.com/open-sauced/pizza-cli/cmd/bake"
 	repoquery "github.com/open-sauced/pizza-cli/cmd/repo-query"
 )
@@ -19,6 +20,7 @@ func NewRootCommand() (*cobra.Command, error) {
 
 	cmd.AddCommand(bake.NewBakeCommand())
 	cmd.AddCommand(repoquery.NewRepoQueryCommand())
+	cmd.AddCommand(auth.NewLoginCommand())
 
 	return cmd, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,6 @@ require (
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	golang.org/x/sys v0.9.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,14 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.9.0 h1:KS/R3tvhPqvJvwcKfnBHJwwthS11LRhmM5D59eEXa0s=
 golang.org/x/sys v0.9.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.9.0 h1:GRRCnKYhdQrD8kfRAdQ6Zcw1P0OcELxGLKJvtjVMZ28=


### PR DESCRIPTION
## Description
This PR adds authentication to the application.
As mentioned in #20, the auth info is written to `~/.pizza/session.json`.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
Resolves #20.

## Mobile & Desktop Screenshots/Recordings
![pizza-cli-auth](https://github.com/open-sauced/pizza-cli/assets/46051506/ac2a3c1a-152c-4aa8-ba8d-830547b4b643)


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed