### PR TITLE
fix: validate period flag

### DIFF
--- a/cmd/insights/contributors.go
+++ b/cmd/insights/contributors.go
@@ -59,11 +59,15 @@ func NewContributorsCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&opts.FilePath, constants.FlagNameFile, "f", "", "Path to yaml file containing an array of git repository urls")
-	cmd.Flags().Int32VarP(&opts.Period, constants.FlagNamePeriod, "p", 30, "Number of days, used for query filtering")
+	cmd.Flags().Int32VarP(&opts.Period, constants.FlagNamePeriod, "p", 30, "Number of days, used for query filtering (7,30,90)")
 	return cmd
 }
 
 func (opts *contributorsOptions) run(ctx context.Context) error {
+	if !api.IsValidRange(opts.Period) {
+		return fmt.Errorf("invalid period: %d, accepts (7,30,90)", opts.Period)
+	}
+
 	repositories, err := utils.HandleRepositoryValues(opts.Repos, opts.FilePath)
 	if err != nil {
 		return err

--- a/pkg/api/validation.go
+++ b/pkg/api/validation.go
@@ -1,0 +1,5 @@
+package api
+
+func IsValidRange(period int32) bool {
+	return period == 7 || period == 30 || period == 90
+}


### PR DESCRIPTION
## Description
This PR adds a range validation to the ```insights contributors``` command. It will check for the value of the period flag. In case the period provided is invalid, it returns a descriptive error to signal that the API only accepts (7,30,90) as period values.

Before
```bash 
$ pizza insights contributors open-sauced/app -p 45
Error: error while calling 'ContributorsServiceAPI.FindAllRecentPullRequestContributors' with repository 501028599': 400 Bad Request
error while calling 'ContributorsServiceAPI.FindAllRepeatPullRequestContributors' with repository 501028599: 400 Bad Request
error while calling 'ContributorsServiceAPI.FindAllChurnPullRequestContributors' with repository 501028599': 400 Bad Request
error while calling 'ContributorsServiceAPI.NewPullRequestContributors' with repository 501028599': 400 Bad Request

Usage:
  pizza insights contributors url... [flags]
...
```

Now
```bash 
$ pizza insights contributors open-sauced/app -p 45
Error: invalid period: 45, accepts (7,30,90)

Usage:
  pizza insights contributors url... [flags]
...
```

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
#66 --period flag broken
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
