### PR TITLE
chore: Include pizza cli specific issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,30 @@
+name: 🐛 Bug report
+description: Create a bug report to help us improve the OpenSauced CLI 🍕
+title: "Bug: "
+labels: [👀 needs triage, 🐛 bug, pizza-cli]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: Describe how to reproduce the behavior.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        Please include the following
+
+        1. System settings
+        2. Operating system version and special configurations
+        3. Shell environment (`echo $SHELL`) and version
+        4. `pizza version` output

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: ❓ Ask a question
+    url: https://github.com/orgs/open-sauced/discussions
+    about: Ask questions about OpenSauced
+  - name: 🪿 Security
+    url: mailto:security@opensauced.pizza
+    about: Contact us about security concerns

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,13 @@
+name: 🚀 Feature request
+description: Suggest an idea for the Pizza CLI 💡
+title: "Feature: "
+labels: [👀 needs triage, 💡 feature, pizza-cli]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+  - type: textarea
+    attributes:
+      label: Suggested solution
+      description: Describe the solution you'd like.


### PR DESCRIPTION
## Description

These are pizza CLI specific issue templates (which importantly include automatically adding the `pizza-cli` label to issues)

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4