### PR TITLE
feat: added built at to version command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG VERSION
 ARG SHA
+ARG DATETIME
 
 # Get the dependencies downloaded
 WORKDIR /app
@@ -16,6 +17,7 @@ COPY . ./
 RUN go build -ldflags="-s -w \
     -X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}' \
     -X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=${SHA}'" \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
     -o pizza .
 
 # Runner layer

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY . ./
 # Build Go CLI binary
 RUN go build -ldflags="-s -w \
     -X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}' \
-    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=${SHA}'" \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=${SHA}' \
     -X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
     -o pizza .
 

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -13,7 +13,7 @@ func NewVersionCommand() *cobra.Command {
 		Use:   "version",
 		Short: "Displays the build version of the CLI",
 		Run: func(_ *cobra.Command, _ []string) {
-			fmt.Printf("Version: %s\nSha: %s\n", utils.Version, utils.Sha)
+			fmt.Printf("Version: %s\nSha: %s\nBuilt at: %s\n", utils.Version, utils.Sha, utils.Datetime)
 		},
 	}
 }

--- a/justfile
+++ b/justfile
@@ -28,6 +28,7 @@ build-darwin-amd64:
   echo "Building darwin amd64"
 
   export VERSION="${RELEASE_TAG_VERSION:-dev}"
+  export DATETIME=$(date -u +"%Y-%m-%d %H:%M:%S")
   export CGO_ENABLED=0
   export GOOS="darwin"
   export GOARCH="amd64"
@@ -45,6 +46,7 @@ build-darwin-arm64:
   echo "Building darwin arm64"
 
   export VERSION="${RELEASE_TAG_VERSION:-dev}"
+  export DATETIME=$(date -u +"%Y-%m-%d %H:%M:%S")
   export CGO_ENABLED=0
   export GOOS="darwin"
   export GOARCH="arm64"
@@ -62,6 +64,7 @@ build-linux-amd64:
   echo "Building linux amd64"
 
   export VERSION="${RELEASE_TAG_VERSION:-dev}"
+  export DATETIME=$(date -u +"%Y-%m-%d %H:%M:%S")
   export CGO_ENABLED=0
   export GOOS="linux"
   export GOARCH="amd64"
@@ -79,6 +82,7 @@ build-linux-arm64:
   echo "Building linux arm64"
 
   export VERSION="${RELEASE_TAG_VERSION:-dev}"
+  export DATETIME=$(date -u +"%Y-%m-%d %H:%M:%S")
   export CGO_ENABLED=0
   export GOOS="linux"
   export GOARCH="arm64"
@@ -96,6 +100,7 @@ build-windows-amd64:
   echo "Building windows amd64"
 
   export VERSION="${RELEASE_TAG_VERSION:-dev}"
+  export DATETIME=$(date -u +"%Y-%m-%d %H:%M:%S")
   export CGO_ENABLED=0
   export GOOS="windows"
   export GOARCH="amd64"
@@ -113,6 +118,7 @@ build-windows-arm64:
   echo "Building windows arm64"
 
   export VERSION="${RELEASE_TAG_VERSION:-dev}"
+  export DATETIME=$(date -u +"%Y-%m-%d %H:%M:%S")
   export CGO_ENABLED=0
   export GOOS="windows"
   export GOARCH="arm64"

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ build:
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
-    -o build/pizza
+    -o build/pizza-${GOOS}-${GOARCH}
 
 install: build
   sudo cp "./build/pizza" "/usr/local/bin/"
@@ -37,6 +37,7 @@ build-darwin-amd64:
     -ldflags="-s -w" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
+    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
     -o build/pizza-${GOOS}-${GOARCH}
 
 build-darwin-arm64:
@@ -53,6 +54,7 @@ build-darwin-arm64:
     -ldflags="-s -w" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
+    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
     -o build/pizza-${GOOS}-${GOARCH}
 
 build-linux-amd64:
@@ -69,6 +71,7 @@ build-linux-amd64:
     -ldflags="-s -w" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
+    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
     -o build/pizza-${GOOS}-${GOARCH}
 
 build-linux-arm64:
@@ -85,6 +88,7 @@ build-linux-arm64:
     -ldflags="-s -w" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
+    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
     -o build/pizza-${GOOS}-${GOARCH}
 
 build-windows-amd64:
@@ -101,6 +105,7 @@ build-windows-amd64:
     -ldflags="-s -w" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
+    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
     -o build/pizza-${GOOS}-${GOARCH}
 
 build-windows-arm64:
@@ -117,6 +122,7 @@ build-windows-arm64:
     -ldflags="-s -w" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
+    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
     -o build/pizza-${GOOS}-${GOARCH}
 
 # Builds the container and marks it tagged as "dev" locally
@@ -124,6 +130,7 @@ build-container:
   docker build \
     --build-arg VERSION=$(git describe --tags --always) \
     --build-arg SHA=$(git rev-parse HEAD) \
+    --build-arg DATETIME=$(date -u +"%Y-%m-%d %H:%M:%S") \
     -t pizza:dev .
 
 clean:

--- a/justfile
+++ b/justfile
@@ -4,11 +4,14 @@ build:
   echo "Building for local arch"
 
   export VERSION="${RELEASE_TAG_VERSION:-dev}"
+  export DATETIME=$(date -u +"%Y-%m-%dT%H:%M:%S")
 
   go build \
     -ldflags="-s -w" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
+    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
+    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
     -o build/pizza
 
 install: build

--- a/justfile
+++ b/justfile
@@ -133,9 +133,9 @@ build-windows-arm64:
 # Builds the container and marks it tagged as "dev" locally
 build-container:
   docker build \
-    --build-arg VERSION=$(git describe --tags --always) \
-    --build-arg SHA=$(git rev-parse HEAD) \
-    --build-arg DATETIME=$(date -u +"%Y-%m-%d %H:%M:%S") \
+    --build-arg VERSION="$(git describe --tags --always)" \
+    --build-arg SHA="$(git rev-parse HEAD)" \
+    --build-arg DATETIME="$(date -u +'%Y-%m-%d %H:%M:%S')" \
     -t pizza:dev .
 
 clean:

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ build:
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
-    -o build/pizza-${GOOS}-${GOARCH}
+    -o build/pizza
 
 install: build
   sudo cp "./build/pizza" "/usr/local/bin/"

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ build:
   echo "Building for local arch"
 
   export VERSION="${RELEASE_TAG_VERSION:-dev}"
-  export DATETIME=$(date -u +"%Y-%m-%dT%H:%M:%S")
+  export DATETIME=$(date -u +"%Y-%m-%d %H:%M:%S")
 
   go build \
     -ldflags="-s -w" \

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ build:
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
-    -o build/pizza
+    -o build/pizza-${GOOS}-${GOARCH}
 
 install: build
   sudo cp "./build/pizza" "/usr/local/bin/"

--- a/justfile
+++ b/justfile
@@ -10,7 +10,6 @@ build:
     -ldflags="-s -w" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
     -o build/pizza
 

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ build:
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
-    -o build/pizza-${GOOS}-${GOARCH}
+    -o build/pizza
 
 install: build
   sudo cp "./build/pizza" "/usr/local/bin/"

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -1,6 +1,7 @@
 package utils
 
 var (
-	Version = "dev"
-	Sha     = "HEAD"
+	Version  = "dev"
+	Sha      = "HEAD"
+	Datetime = "dev"
 )


### PR DESCRIPTION
## Description

Adds built at time to the pizza `version` command.

## Related Tickets & Documents

Closes #86

## Mobile & Desktop Screenshots/Recordings

N/A


## Steps to QA

1. Run `just install`.
2. Run `pizza version`.
3. Notice the build date in the version now.

    ```
	❯ pizza version
	Version: dev
	Sha: HEAD
	Built at: 2024-08-26 20:10:06
    ```
4. Run `just build-all`.
5. Everything compiles still for all build targets.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/F0uUtL7lmALCM/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
