### PR TITLE
feat: Upgrade Go module to use Go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-sauced/pizza-cli
 
-go 1.21
+go 1.22
 
 require (
 	github.com/charmbracelet/bubbles v0.19.0


### PR DESCRIPTION
## Description

Small change to upgrade the Go module to Go 1.22

## Related Tickets & Documents

N/a

## Steps to QA

Able to `just build-all`

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4