### PR TITLE
fix: Root command persistent flags are marked hidden correctly

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -44,14 +44,14 @@ func NewRootCommand() (*cobra.Command, error) {
 	cmd.AddCommand(insights.NewInsightsCommand())
 	cmd.AddCommand(version.NewVersionCommand())
 
-	err := cmd.Flags().MarkHidden(constants.FlagNameEndpoint)
+	err := cmd.PersistentFlags().MarkHidden(constants.FlagNameEndpoint)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error marking %s as hidden: %w", constants.FlagNameEndpoint, err)
 	}
 
-	err = cmd.Flags().MarkHidden(constants.FlagNameBeta)
+	err = cmd.PersistentFlags().MarkHidden(constants.FlagNameBeta)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error marking %s as hidden: %w", constants.FlagNameBeta, err)
 	}
 
 	return cmd, nil


### PR DESCRIPTION
## Description

Root command now correctly marks persistent flags as hidden. It was giving:

```
❯ ./build/pizza
2024/08/30 11:01:05 error marking endpoint as hidden: flag "endpoint" does not exist
```

## Related Tickets & Documents

Followup to #113 

## Steps to QA

1. Build via `just build`
2. Run with `./build/pizza` and output is corrected

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4
