### PR TITLE
feat: now the documentation for the pizza-cli can be generated via pizza docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Ignore stuff from the builds that get generated.
 build/
+docs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 # Ignore stuff from the builds that get generated.
 build/
-docs/

--- a/cmd/docs/docs.go
+++ b/cmd/docs/docs.go
@@ -24,7 +24,7 @@ func NewDocsCommand() *cobra.Command {
 		Short: "Generates the documentation for the CLI",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.DisableAutoGenTag = true
+			cmd.Parent().Root().DisableAutoGenTag = true
 
 			// Use default path if no argument is provided
 			if len(args) == 0 {

--- a/cmd/docs/docs.go
+++ b/cmd/docs/docs.go
@@ -21,13 +21,7 @@ func DeterminePath(args []string) (string, error) {
 		return DefaultPath, nil
 	}
 
-	absPath, err := filepath.Abs(args[0])
-
-	if err != nil {
-		return "", err
-	}
-
-	return absPath, nil
+	return filepath.Abs(args[0])
 }
 
 func EnsureDirectoryExists(path string) error {

--- a/cmd/docs/docs.go
+++ b/cmd/docs/docs.go
@@ -24,6 +24,8 @@ func NewDocsCommand() *cobra.Command {
 		Short: "Generates the documentation for the CLI",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.DisableAutoGenTag = true
+
 			// Use default path if no argument is provided
 			if len(args) == 0 {
 				opts.path = DefaultPath

--- a/cmd/docs/docs.go
+++ b/cmd/docs/docs.go
@@ -1,0 +1,62 @@
+package docs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+type Options struct {
+	// the path to generate the documentation in
+	path string
+}
+
+const DefaultPath = "./docs"
+
+func NewDocsCommand() *cobra.Command {
+	opts := &Options{}
+
+	return &cobra.Command{
+		Use:   "docs",
+		Short: "Generates the documentation for the CLI",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Use default path if no argument is provided
+			if len(args) == 0 {
+				opts.path = DefaultPath
+				fmt.Printf("No path was provided. Using default path: %s\n", DefaultPath)
+			} else {
+				absPath, err := filepath.Abs(args[0])
+				if err != nil {
+					return err
+				}
+				opts.path = absPath
+			}
+
+			// Create the directory if it doesn't exist
+			_, err := os.Stat(opts.path)
+			if os.IsNotExist(err) {
+				fmt.Printf("The directory %s does not exist. Creating it...\n", opts.path)
+
+				err := os.MkdirAll(opts.path, os.ModePerm)
+				if err != nil {
+					return fmt.Errorf("error creating documentation output directory %s: %s", opts.path, err)
+				}
+			}
+
+			// Generate markdown documentation
+			fmt.Printf("Generating documentation in %s...\n", opts.path)
+			err = doc.GenMarkdownTree(cmd, opts.path)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Finished generating documentation in %s\n", opts.path)
+
+			return nil
+		},
+	}
+}

--- a/cmd/docs/docs.go
+++ b/cmd/docs/docs.go
@@ -51,7 +51,8 @@ func NewDocsCommand() *cobra.Command {
 
 			// Generate markdown documentation
 			fmt.Printf("Generating documentation in %s...\n", opts.path)
-			err = doc.GenMarkdownTree(cmd, opts.path)
+
+			err = doc.GenMarkdownTree(cmd.Parent().Root(), opts.path)
 			if err != nil {
 				return err
 			}

--- a/cmd/docs/docs_test.go
+++ b/cmd/docs/docs_test.go
@@ -1,0 +1,107 @@
+package docs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDocsCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Docs generate using default path", func(t *testing.T) {
+		t.Parallel()
+		cmd := NewDocsCommand()
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		// Check if a Markdown file was generated
+		files, err := os.ReadDir(DefaultPath)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, files)
+
+		markdownFileFound := false
+
+		for _, file := range files {
+			if strings.HasSuffix(file.Name(), ".md") {
+				markdownFileFound = true
+				break
+			}
+		}
+
+		assert.True(t, markdownFileFound, "No Markdown file was generated in the default path")
+
+		os.RemoveAll(DefaultPath)
+	})
+
+	t.Run("Docs generate using a custom path", func(t *testing.T) {
+		t.Parallel()
+		tempDir := t.TempDir()
+		customPath := filepath.Join(tempDir, "custom_docs")
+
+		cmd := NewDocsCommand()
+		cmd.SetArgs([]string{customPath})
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		// Check if a Markdown file was generated
+		files, err := os.ReadDir(customPath)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, files)
+
+		markdownFileFound := false
+
+		for _, file := range files {
+			if strings.HasSuffix(file.Name(), ".md") {
+				markdownFileFound = true
+				break
+			}
+		}
+
+		assert.True(t, markdownFileFound, "No Markdown file was generated in the custom path")
+	})
+
+	t.Run("Docs fail to generate when the output path is invalid", func(t *testing.T) {
+		t.Parallel()
+		cmd := NewDocsCommand()
+		cmd.SetArgs([]string{string([]byte{0x00})})
+		err := cmd.Execute()
+		assert.Error(t, err)
+	})
+
+	t.Run("Docs generate using an existing directory", func(t *testing.T) {
+		t.Parallel()
+		tempDir := t.TempDir()
+
+		cmd := NewDocsCommand()
+		cmd.SetArgs([]string{tempDir})
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		// Check if files were generated in the existing directory
+		files, err := os.ReadDir(tempDir)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, files)
+
+		markdownFileFound := false
+		for _, file := range files {
+			if strings.HasSuffix(file.Name(), ".md") {
+				markdownFileFound = true
+				break
+			}
+		}
+		assert.True(t, markdownFileFound, "No Markdown file was generated in the existing directory")
+	})
+
+	t.Run("TooManyArguments", func(t *testing.T) {
+		t.Parallel()
+		cmd := NewDocsCommand()
+		cmd.SetArgs([]string{"path1", "path2"})
+		err := cmd.Execute()
+		assert.Error(t, err)
+	})
+}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-sauced/pizza-cli/cmd/auth"
+	"github.com/open-sauced/pizza-cli/cmd/docs"
 	"github.com/open-sauced/pizza-cli/cmd/generate"
 	"github.com/open-sauced/pizza-cli/cmd/insights"
 	"github.com/open-sauced/pizza-cli/cmd/version"
@@ -43,6 +44,7 @@ func NewRootCommand() (*cobra.Command, error) {
 	cmd.AddCommand(generate.NewGenerateCommand())
 	cmd.AddCommand(insights.NewInsightsCommand())
 	cmd.AddCommand(version.NewVersionCommand())
+	cmd.AddCommand(docs.NewDocsCommand())
 
 	err := cmd.PersistentFlags().MarkHidden(constants.FlagNameEndpoint)
 	if err != nil {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -44,7 +44,11 @@ func NewRootCommand() (*cobra.Command, error) {
 	cmd.AddCommand(generate.NewGenerateCommand())
 	cmd.AddCommand(insights.NewInsightsCommand())
 	cmd.AddCommand(version.NewVersionCommand())
-	cmd.AddCommand(docs.NewDocsCommand())
+
+	// The docs command is hidden as it's only used by the pizza-cli maintainers
+	docsCmd := docs.NewDocsCommand()
+	docsCmd.Hidden = true
+	cmd.AddCommand(docsCmd)
 
 	err := cmd.PersistentFlags().MarkHidden(constants.FlagNameEndpoint)
 	if err != nil {

--- a/docs/pizza.md
+++ b/docs/pizza.md
@@ -1,0 +1,30 @@
+## pizza
+
+OpenSauced CLI
+
+### Synopsis
+
+A command line utility for insights, metrics, and all things OpenSauced
+
+```
+pizza <command> <subcommand> [flags]
+```
+
+### Options
+
+```
+  -c, --config string       The saucectl config (default "~/.sauced.yaml")
+      --disable-telemetry   Disable sending telemetry data to OpenSauced
+  -h, --help                help for pizza
+  -l, --log-level string    The logging level. Options: error, warn, info, debug (default "info")
+      --tty-disable         Disable log stylization. Suitable for CI/CD and automation
+```
+
+### SEE ALSO
+
+* [pizza completion](pizza_completion.md)	 - Generate the autocompletion script for the specified shell
+* [pizza generate](pizza_generate.md)	 - Generates something
+* [pizza insights](pizza_insights.md)	 - Gather insights about git contributors, repositories, users and pull requests
+* [pizza login](pizza_login.md)	 - Log into the CLI via GitHub
+* [pizza version](pizza_version.md)	 - Displays the build version of the CLI
+

--- a/docs/pizza_completion.md
+++ b/docs/pizza_completion.md
@@ -1,0 +1,33 @@
+## pizza completion
+
+Generate the autocompletion script for the specified shell
+
+### Synopsis
+
+Generate the autocompletion script for pizza for the specified shell.
+See each sub-command's help for details on how to use the generated script.
+
+
+### Options
+
+```
+  -h, --help   help for completion
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string       The saucectl config (default "~/.sauced.yaml")
+      --disable-telemetry   Disable sending telemetry data to OpenSauced
+  -l, --log-level string    The logging level. Options: error, warn, info, debug (default "info")
+      --tty-disable         Disable log stylization. Suitable for CI/CD and automation
+```
+
+### SEE ALSO
+
+* [pizza](pizza.md)	 - OpenSauced CLI
+* [pizza completion bash](pizza_completion_bash.md)	 - Generate the autocompletion script for bash
+* [pizza completion fish](pizza_completion_fish.md)	 - Generate the autocompletion script for fish
+* [pizza completion powershell](pizza_completion_powershell.md)	 - Generate the autocompletion script for powershell
+* [pizza completion zsh](pizza_completion_zsh.md)	 - Generate the autocompletion script for zsh
+

--- a/docs/pizza_completion_bash.md
+++ b/docs/pizza_completion_bash.md
@@ -1,0 +1,52 @@
+## pizza completion bash
+
+Generate the autocompletion script for bash
+
+### Synopsis
+
+Generate the autocompletion script for the bash shell.
+
+This script depends on the 'bash-completion' package.
+If it is not installed already, you can install it via your OS's package manager.
+
+To load completions in your current shell session:
+
+	source <(pizza completion bash)
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+	pizza completion bash > /etc/bash_completion.d/pizza
+
+#### macOS:
+
+	pizza completion bash > $(brew --prefix)/etc/bash_completion.d/pizza
+
+You will need to start a new shell for this setup to take effect.
+
+
+```
+pizza completion bash
+```
+
+### Options
+
+```
+  -h, --help              help for bash
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string       The saucectl config (default "~/.sauced.yaml")
+      --disable-telemetry   Disable sending telemetry data to OpenSauced
+  -l, --log-level string    The logging level. Options: error, warn, info, debug (default "info")
+      --tty-disable         Disable log stylization. Suitable for CI/CD and automation
+```
+
+### SEE ALSO
+
+* [pizza completion](pizza_completion.md)	 - Generate the autocompletion script for the specified shell
+

--- a/docs/pizza_completion_fish.md
+++ b/docs/pizza_completion_fish.md
@@ -1,0 +1,43 @@
+## pizza completion fish
+
+Generate the autocompletion script for fish
+
+### Synopsis
+
+Generate the autocompletion script for the fish shell.
+
+To load completions in your current shell session:
+
+	pizza completion fish | source
+
+To load completions for every new session, execute once:
+
+	pizza completion fish > ~/.config/fish/completions/pizza.fish
+
+You will need to start a new shell for this setup to take effect.
+
+
+```
+pizza completion fish [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for fish
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string       The saucectl config (default "~/.sauced.yaml")
+      --disable-telemetry   Disable sending telemetry data to OpenSauced
+  -l, --log-level string    The logging level. Options: error, warn, info, debug (default "info")
+      --tty-disable         Disable log stylization. Suitable for CI/CD and automation
+```
+
+### SEE ALSO
+
+* [pizza completion](pizza_completion.md)	 - Generate the autocompletion script for the specified shell
+

--- a/docs/pizza_completion_powershell.md
+++ b/docs/pizza_completion_powershell.md
@@ -1,0 +1,40 @@
+## pizza completion powershell
+
+Generate the autocompletion script for powershell
+
+### Synopsis
+
+Generate the autocompletion script for powershell.
+
+To load completions in your current shell session:
+
+	pizza completion powershell | Out-String | Invoke-Expression
+
+To load completions for every new session, add the output of the above command
+to your powershell profile.
+
+
+```
+pizza completion powershell [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for powershell
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string       The saucectl config (default "~/.sauced.yaml")
+      --disable-telemetry   Disable sending telemetry data to OpenSauced
+  -l, --log-level string    The logging level. Options: error, warn, info, debug (default "info")
+      --tty-disable         Disable log stylization. Suitable for CI/CD and automation
+```
+
+### SEE ALSO
+
+* [pizza completion](pizza_completion.md)	 - Generate the autocompletion script for the specified shell
+

--- a/docs/pizza_completion_zsh.md
+++ b/docs/pizza_completion_zsh.md
@@ -1,0 +1,54 @@
+## pizza completion zsh
+
+Generate the autocompletion script for zsh
+
+### Synopsis
+
+Generate the autocompletion script for the zsh shell.
+
+If shell completion is not already enabled in your environment you will need
+to enable it.  You can execute the following once:
+
+	echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+To load completions in your current shell session:
+
+	source <(pizza completion zsh)
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+	pizza completion zsh > "${fpath[1]}/_pizza"
+
+#### macOS:
+
+	pizza completion zsh > $(brew --prefix)/share/zsh/site-functions/_pizza
+
+You will need to start a new shell for this setup to take effect.
+
+
+```
+pizza completion zsh [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for zsh
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string       The saucectl config (default "~/.sauced.yaml")
+      --disable-telemetry   Disable sending telemetry data to OpenSauced
+  -l, --log-level string    The logging level. Options: error, warn, info, debug (default "info")
+      --tty-disable         Disable log stylization. Suitable for CI/CD and automation
+```
+
+### SEE ALSO
+
+* [pizza completion](pizza_completion.md)	 - Generate the autocompletion script for the specified shell
+

--- a/docs/pizza_generate.md
+++ b/docs/pizza_generate.md
@@ -1,0 +1,34 @@
+## pizza generate
+
+Generates something
+
+### Synopsis
+
+WARNING: Proof of concept feature.
+
+XXX
+
+```
+pizza generate [subcommand] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for generate
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string       The saucectl config (default "~/.sauced.yaml")
+      --disable-telemetry   Disable sending telemetry data to OpenSauced
+  -l, --log-level string    The logging level. Options: error, warn, info, debug (default "info")
+      --tty-disable         Disable log stylization. Suitable for CI/CD and automation
+```
+
+### SEE ALSO
+
+* [pizza](pizza.md)	 - OpenSauced CLI
+* [pizza generate codeowners](pizza_generate_codeowners.md)	 - Generates a CODEOWNERS file for a given repository using a "~/.sauced.yaml" config
+

--- a/docs/pizza_generate_codeowners.md
+++ b/docs/pizza_generate_codeowners.md
@@ -1,0 +1,39 @@
+## pizza generate codeowners
+
+Generates a CODEOWNERS file for a given repository using a "~/.sauced.yaml" config
+
+### Synopsis
+
+WARNING: Proof of concept feature.
+
+Generates a CODEOWNERS file for a given git repository. This uses a ~/.sauced.yaml
+configuration to attribute emails with given entities.
+
+The generated file specifies up to 3 owners for EVERY file in the git tree based on the
+number of lines touched in that specific file over the specified range of time.
+
+```
+pizza generate codeowners path/to/repo [flags]
+```
+
+### Options
+
+```
+  -h, --help                help for codeowners
+      --owners-style-file   Whether to generate an agnostic OWNERS style file.
+  -r, --range int           The number of days to lookback (default 90)
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string       The saucectl config (default "~/.sauced.yaml")
+      --disable-telemetry   Disable sending telemetry data to OpenSauced
+  -l, --log-level string    The logging level. Options: error, warn, info, debug (default "info")
+      --tty-disable         Disable log stylization. Suitable for CI/CD and automation
+```
+
+### SEE ALSO
+
+* [pizza generate](pizza_generate.md)	 - Generates something
+

--- a/docs/pizza_insights.md
+++ b/docs/pizza_insights.md
@@ -1,0 +1,35 @@
+## pizza insights
+
+Gather insights about git contributors, repositories, users and pull requests
+
+### Synopsis
+
+Gather insights about git contributors, repositories, user and pull requests and display the results
+
+```
+pizza insights <command> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for insights
+  -o, --output string   The formatting for command output. One of: (table, yaml, csv, json) (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string       The saucectl config (default "~/.sauced.yaml")
+      --disable-telemetry   Disable sending telemetry data to OpenSauced
+  -l, --log-level string    The logging level. Options: error, warn, info, debug (default "info")
+      --tty-disable         Disable log stylization. Suitable for CI/CD and automation
+```
+
+### SEE ALSO
+
+* [pizza](pizza.md)	 - OpenSauced CLI
+* [pizza insights contributors](pizza_insights_contributors.md)	 - Gather insights about contributors of indexed git repositories
+* [pizza insights repositories](pizza_insights_repositories.md)	 - Gather insights about indexed git repositories
+* [pizza insights user-contributions](pizza_insights_user-contributions.md)	 - Gather insights on individual contributors for given repo URLs
+

--- a/docs/pizza_insights_contributors.md
+++ b/docs/pizza_insights_contributors.md
@@ -1,0 +1,34 @@
+## pizza insights contributors
+
+Gather insights about contributors of indexed git repositories
+
+### Synopsis
+
+Gather insights about contributors of indexed git repositories. This command will show new, recent, alumni, repeat contributors for each git repository
+
+```
+pizza insights contributors url... [flags]
+```
+
+### Options
+
+```
+  -f, --file string   Path to yaml file containing an array of git repository urls
+  -h, --help          help for contributors
+  -r, --range int     Number of days to look-back (7,30,90) (default 30)
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string       The saucectl config (default "~/.sauced.yaml")
+      --disable-telemetry   Disable sending telemetry data to OpenSauced
+  -l, --log-level string    The logging level. Options: error, warn, info, debug (default "info")
+  -o, --output string       The formatting for command output. One of: (table, yaml, csv, json) (default "table")
+      --tty-disable         Disable log stylization. Suitable for CI/CD and automation
+```
+
+### SEE ALSO
+
+* [pizza insights](pizza_insights.md)	 - Gather insights about git contributors, repositories, users and pull requests
+

--- a/docs/pizza_insights_repositories.md
+++ b/docs/pizza_insights_repositories.md
@@ -1,0 +1,34 @@
+## pizza insights repositories
+
+Gather insights about indexed git repositories
+
+### Synopsis
+
+Gather insights about indexed git repositories. This command will show info about contributors, pull requests, etc.
+
+```
+pizza insights repositories url... [flags]
+```
+
+### Options
+
+```
+  -f, --file string   Path to yaml file containing an array of git repository urls
+  -h, --help          help for repositories
+  -p, --range int     Number of days to look-back (default 30)
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string       The saucectl config (default "~/.sauced.yaml")
+      --disable-telemetry   Disable sending telemetry data to OpenSauced
+  -l, --log-level string    The logging level. Options: error, warn, info, debug (default "info")
+  -o, --output string       The formatting for command output. One of: (table, yaml, csv, json) (default "table")
+      --tty-disable         Disable log stylization. Suitable for CI/CD and automation
+```
+
+### SEE ALSO
+
+* [pizza insights](pizza_insights.md)	 - Gather insights about git contributors, repositories, users and pull requests
+

--- a/docs/pizza_insights_user-contributions.md
+++ b/docs/pizza_insights_user-contributions.md
@@ -1,0 +1,36 @@
+## pizza insights user-contributions
+
+Gather insights on individual contributors for given repo URLs
+
+### Synopsis
+
+Gather insights on individual contributors given a list of repository URLs
+
+```
+pizza insights user-contributions url... [flags]
+```
+
+### Options
+
+```
+  -f, --file string     Path to yaml file containing an array of git repository urls
+  -h, --help            help for user-contributions
+  -p, --range int32     Number of days, used for query filtering (default 30)
+  -s, --sort string     Sort user contributions by (total, commits, prs) (default "none")
+  -u, --users strings   Inclusive comma separated list of GitHub usernames to filter for
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string       The saucectl config (default "~/.sauced.yaml")
+      --disable-telemetry   Disable sending telemetry data to OpenSauced
+  -l, --log-level string    The logging level. Options: error, warn, info, debug (default "info")
+  -o, --output string       The formatting for command output. One of: (table, yaml, csv, json) (default "table")
+      --tty-disable         Disable log stylization. Suitable for CI/CD and automation
+```
+
+### SEE ALSO
+
+* [pizza insights](pizza_insights.md)	 - Gather insights about git contributors, repositories, users and pull requests
+

--- a/docs/pizza_login.md
+++ b/docs/pizza_login.md
@@ -1,0 +1,34 @@
+## pizza login
+
+Log into the CLI via GitHub
+
+### Synopsis
+
+Log into the OpenSauced CLI.
+
+This command initiates the GitHub auth flow to log you into the OpenSauced CLI
+by launching your browser and logging in with GitHub.
+
+```
+pizza login [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for login
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string       The saucectl config (default "~/.sauced.yaml")
+      --disable-telemetry   Disable sending telemetry data to OpenSauced
+  -l, --log-level string    The logging level. Options: error, warn, info, debug (default "info")
+      --tty-disable         Disable log stylization. Suitable for CI/CD and automation
+```
+
+### SEE ALSO
+
+* [pizza](pizza.md)	 - OpenSauced CLI
+

--- a/docs/pizza_version.md
+++ b/docs/pizza_version.md
@@ -1,0 +1,27 @@
+## pizza version
+
+Displays the build version of the CLI
+
+```
+pizza version [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for version
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string       The saucectl config (default "~/.sauced.yaml")
+      --disable-telemetry   Disable sending telemetry data to OpenSauced
+  -l, --log-level string    The logging level. Options: error, warn, info, debug (default "info")
+      --tty-disable         Disable log stylization. Suitable for CI/CD and automation
+```
+
+### SEE ALSO
+
+* [pizza](pizza.md)	 - OpenSauced CLI
+

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,11 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require github.com/charmbracelet/bubbletea v0.27.1 // indirect
+require (
+	github.com/charmbracelet/bubbletea v0.27.1 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+)
 
 require (
 	dario.cat/mergo v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,7 @@ github.com/cli/browser v1.3.0/go.mod h1:HH8s+fOAxjhQoBUAsKuPCbqUuxZDhQ2/aD+SzsEf
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
+github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
@@ -107,6 +108,7 @@ github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=


### PR DESCRIPTION
## Description

Now the documentation for the pizza-cli can be generated via the `docs` command, e.g. `pizza docs`. By default if no path is specified, the default path, `"./docs"` will be used.

## Related Tickets & Documents

Closes #120

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA

1. Run `just build`
2. Run `./build/pizza docs`
3. Notice docs get generated in the `./docs` folder.
4. Run `./build pizza docs ./docs2`.
5. Notice docs get generated in the `./docs2` folder.

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/8Ue8ekoT67ylq/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
