### PR TITLE
chore: Remove flaky default config test

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -94,11 +94,4 @@ attribution:
 		assert.Equal(t, []string{"nick@nickyt.co", "nick@opensauced.pizza"}, config.Attributions["nickytonline"])
 		assert.Equal(t, []string{"coding@zeu.dev"}, config.Attributions["zeucapua"])
 	})
-
-	//t.Run("Default path", func(t *testing.T) {
-	//t.Parallel()
-	//config, err := LoadConfig(DefaultConfigPath, "")
-	//assert.Error(t, err)
-	//assert.Nil(t, config)
-	//})
 }


### PR DESCRIPTION
## Description

This removes a flaky test that wasn't doing much for us: in the case that there's a valid `~/.sauced.yaml` in the user's home directory, this test would blow up. 

We _could_ in theory build some tooling to completely isolate the tests in a separate in memory file system, but that would be alot of effort for standard lib functionality that would probably be better served by e2e tests.

## Related Tickets & Documents

Closes: https://github.com/open-sauced/pizza-cli/issues/132

## Steps to QA

1. Run `just test` - tests pass with a valid `~/.sauced.yaml` in the user's home directory:

```
❯ file ~/.sauced.yaml
/Users/jpmcb/.sauced.yaml: ASCII text
```

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4