### PR TITLE
fix: Revive Posthog's write only key

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+# Env vars used in the justfile during buildtime
+
+POSTHOG_PUBLIC_API_KEY="phc_Y0xz6nK55MEwWjobJsI2P8rsiomZJ6eZLoXehmMy9tt"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59.1
+          version: v1.60
 
   test:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG BUILDPLATFORM
 ARG VERSION
 ARG SHA
 ARG DATETIME
+ARG POSTHOG_PUBLIC_API_KEY
 
 # Get the dependencies downloaded
 WORKDIR /app
@@ -17,7 +18,8 @@ COPY . ./
 RUN go build -ldflags="-s -w \
     -X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}' \
     -X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=${SHA}' \
-    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
     -o pizza .
 
 # Runner layer

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -32,19 +32,17 @@ func NewLoginCommand() *cobra.Command {
 		Long:  loginLongDesc,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			username, err := run()
-
 			disableTelem, _ := cmd.Flags().GetBool(constants.FlagNameTelemetry)
 
-			if !disableTelem {
-				opts.telemetry = utils.NewPosthogCliClient()
-				defer opts.telemetry.Done()
+			opts.telemetry = utils.NewPosthogCliClient(!disableTelem)
+			defer opts.telemetry.Done()
 
-				if err != nil {
-					opts.telemetry.CaptureFailedLogin()
-				} else {
-					opts.telemetry.CaptureLogin(username)
-				}
+			username, err := run()
+
+			if err != nil {
+				opts.telemetry.CaptureFailedLogin()
+			} else {
+				opts.telemetry.CaptureLogin(username)
 			}
 
 			return err

--- a/cmd/generate/codeowners/codeowners.go
+++ b/cmd/generate/codeowners/codeowners.go
@@ -16,7 +16,9 @@ import (
 	"github.com/open-sauced/pizza-cli/api/services/workspaces"
 	"github.com/open-sauced/pizza-cli/api/services/workspaces/userlists"
 	"github.com/open-sauced/pizza-cli/pkg/config"
+	"github.com/open-sauced/pizza-cli/pkg/constants"
 	"github.com/open-sauced/pizza-cli/pkg/logging"
+	"github.com/open-sauced/pizza-cli/pkg/utils"
 )
 
 // Options for the codeowners generation command
@@ -37,6 +39,9 @@ type Options struct {
 	logger   gopherlogs.Logger
 	tty      bool
 	loglevel int
+
+	// telemetry for capturing CLI events via PostHog
+	telemetry *utils.PosthogCliClient
 
 	config *config.Spec
 }
@@ -78,6 +83,11 @@ func NewCodeownersCommand() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			var err error
+
+			disableTelem, _ := cmd.Flags().GetBool(constants.FlagNameTelemetry)
+
+			opts.telemetry = utils.NewPosthogCliClient(!disableTelem)
+			defer opts.telemetry.Done()
 
 			configPath, _ := cmd.Flags().GetString("config")
 			opts.config, err = config.LoadConfig(configPath, filepath.Join(opts.path, ".sauced.yaml"))
@@ -125,6 +135,7 @@ func run(opts *Options, cmd *cobra.Command) error {
 
 	repo, err := git.PlainOpen(opts.path)
 	if err != nil {
+		opts.telemetry.CaptureFailedCodeownersGenerate()
 		return fmt.Errorf("error opening repo: %w", err)
 	}
 	opts.logger.V(logging.LogDebug).Style(0, colors.FgBlue).Infof("Opened repo at: %s\n", opts.path)
@@ -139,6 +150,7 @@ func run(opts *Options, cmd *cobra.Command) error {
 
 	codeowners, err := processOptions.process()
 	if err != nil {
+		opts.telemetry.CaptureFailedCodeownersGenerate()
 		return fmt.Errorf("error traversing git log: %w", err)
 	}
 
@@ -153,9 +165,11 @@ func run(opts *Options, cmd *cobra.Command) error {
 	opts.logger.V(logging.LogDebug).Style(0, colors.FgBlue).Infof("Processing codeowners file at: %s\n", outputPath)
 	err = generateOutputFile(codeowners, outputPath, opts, cmd)
 	if err != nil {
+		opts.telemetry.CaptureFailedCodeownersGenerate()
 		return fmt.Errorf("error generating github style codeowners file: %w", err)
 	}
 	opts.logger.V(logging.LogInfo).Style(0, colors.FgGreen).Infof("Finished generating file: %s\n", outputPath)
+	opts.telemetry.CaptureCodeownersGenerate()
 
 	// 1. Ask if they want to add users to a list
 	var input string
@@ -190,9 +204,11 @@ func run(opts *Options, cmd *cobra.Command) error {
 		case "y", "Y", "yes":
 			user, err := authenticator.Login()
 			if err != nil {
+				opts.telemetry.CaptureFailedCodeownersGenerateAuth()
 				opts.logger.V(logging.LogInfo).Style(0, colors.FgRed).Infof("Error logging in\n")
 				return fmt.Errorf("could not log in: %w", err)
 			}
+			opts.telemetry.CaptureCodeownersGenerateAuth(user)
 			opts.logger.V(logging.LogInfo).Style(0, colors.FgGreen).Infof("Logged in as: %s\n", user)
 
 		case "n", "N", "no":
@@ -205,6 +221,7 @@ func run(opts *Options, cmd *cobra.Command) error {
 
 	opts.token, err = authenticator.GetSessionToken()
 	if err != nil {
+		opts.telemetry.CaptureFailedCodeownersGenerateContributorInsight()
 		opts.logger.V(logging.LogInfo).Style(0, colors.FgRed).Infof("Error getting session token\n")
 		return fmt.Errorf("could not get session token: %w", err)
 	}
@@ -214,18 +231,22 @@ func run(opts *Options, cmd *cobra.Command) error {
 	opts.logger.V(logging.LogDebug).Style(0, colors.FgBlue).Infof("Looking up OpenSauced workspace: Pizza CLI\n")
 	workspace, err := findCreatePizzaCliWorkspace(opts)
 	if err != nil {
-		return err
+		opts.telemetry.CaptureFailedCodeownersGenerateContributorInsight()
+		opts.logger.V(logging.LogInfo).Style(0, colors.FgRed).Infof("Error finding Workspace: Pizza CLI\n")
+		return fmt.Errorf("could not find Pizza CLI workspace: %w", err)
 	}
 	opts.logger.V(logging.LogDebug).Style(0, colors.FgGreen).Infof("Found workspace: Pizza CLI\n")
 
 	opts.logger.V(logging.LogDebug).Style(0, colors.FgBlue).Infof("Looking up Contributor Insight for local repository: %s\n", listName)
 	userList, err := updateCreateLocalWorkspaceUserList(opts, listName, workspace, codeowners)
 	if err != nil {
-		return err
+		opts.telemetry.CaptureFailedCodeownersGenerateContributorInsight()
+		opts.logger.V(logging.LogInfo).Style(0, colors.FgRed).Infof("Error finding Workspace Contributor Insight: %s\n", listName)
+		return fmt.Errorf("could not find Workspace Contributor Insight: %s - %w", listName, err)
 	}
 	opts.logger.V(logging.LogDebug).Style(0, colors.FgGreen).Infof("Updated Contributor Insight for local repository: %s\n", listName)
-
 	opts.logger.V(logging.LogInfo).Style(0, colors.FgCyan).Infof("Access list on OpenSauced:\n%s\n", fmt.Sprintf("https://app.opensauced.pizza/workspaces/%s/contributor-insights/%s", workspace.ID, userList.ID))
+	opts.telemetry.CaptureCodeownersGenerateContributorInsight()
 
 	return nil
 }

--- a/cmd/insights/contributors.go
+++ b/cmd/insights/contributors.go
@@ -34,6 +34,8 @@ type contributorsOptions struct {
 
 	// Output is the formatting style for command output
 	Output string
+
+	telemetry *utils.PosthogCliClient
 }
 
 // NewContributorsCommand returns a new cobra command for 'pizza insights contributors'
@@ -52,11 +54,25 @@ func NewContributorsCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			disableTelem, _ := cmd.Flags().GetBool(constants.FlagNameTelemetry)
+
+			opts.telemetry = utils.NewPosthogCliClient(!disableTelem)
+			defer opts.telemetry.Done()
+
 			endpointURL, _ := cmd.Flags().GetString(constants.FlagNameEndpoint)
 			opts.APIClient = api.NewClient(endpointURL)
 			output, _ := cmd.Flags().GetString(constants.FlagNameOutput)
 			opts.Output = output
-			return opts.run()
+
+			err := opts.run()
+
+			if err != nil {
+				opts.telemetry.CaptureInsights()
+			} else {
+				opts.telemetry.CaptureFailedInsights()
+			}
+
+			return err
 		},
 	}
 	cmd.Flags().StringVarP(&opts.FilePath, constants.FlagNameFile, "f", "", "Path to yaml file containing an array of git repository urls")

--- a/cmd/insights/repositories.go
+++ b/cmd/insights/repositories.go
@@ -33,6 +33,8 @@ type repositoriesOptions struct {
 
 	// Output is the formatting style for command output
 	Output string
+
+	telemetry *utils.PosthogCliClient
 }
 
 // NewRepositoriesCommand returns a new cobra command for 'pizza insights repositories'
@@ -52,11 +54,25 @@ func NewRepositoriesCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			disableTelem, _ := cmd.Flags().GetBool(constants.FlagNameTelemetry)
+
+			opts.telemetry = utils.NewPosthogCliClient(!disableTelem)
+			defer opts.telemetry.Done()
+
 			endpointURL, _ := cmd.Flags().GetString(constants.FlagNameEndpoint)
 			opts.APIClient = api.NewClient(endpointURL)
 			output, _ := cmd.Flags().GetString(constants.FlagNameOutput)
 			opts.Output = output
-			return opts.run()
+
+			err := opts.run()
+
+			if err != nil {
+				opts.telemetry.CaptureInsights()
+			} else {
+				opts.telemetry.CaptureFailedInsights()
+			}
+
+			return err
 		},
 	}
 	cmd.Flags().StringVarP(&opts.FilePath, constants.FlagNameFile, "f", "", "Path to yaml file containing an array of git repository urls")

--- a/justfile
+++ b/justfile
@@ -1,4 +1,11 @@
-# Builds the go binary into the git ignored ./build/ dir
+set dotenv-load
+
+# Displays this help message
+help:
+  @echo "Available commands:"
+  @just --list
+
+# Builds the go binary into the git ignored ./build/ dir for the local architecture
 build:
   #!/usr/bin/env sh
   echo "Building for local arch"
@@ -11,17 +18,22 @@ build:
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
+    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
     -o build/pizza
 
+# Builds and installs the go binary for the local architecture. WARNING: requires sudo access
 install: build
   sudo cp "./build/pizza" "/usr/local/bin/"
 
+# Builds all build targets arcross all OS and architectures
 build-all: \
     build \
+    build-container \
     build-darwin-amd64 build-darwin-arm64 \
     build-linux-amd64 build-linux-arm64 \
     build-windows-amd64 build-windows-arm64
 
+# Builds for Darwin linux (i.e., MacOS) on amd64 architecture
 build-darwin-amd64:
   #!/usr/bin/env sh
 
@@ -38,8 +50,10 @@ build-darwin-amd64:
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
+    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
     -o build/pizza-${GOOS}-${GOARCH}
 
+# Builds for Darwin linux (i.e., MacOS) on arm64 architecture (i.e. Apple silicon)
 build-darwin-arm64:
   #!/usr/bin/env sh
 
@@ -56,8 +70,10 @@ build-darwin-arm64:
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
+    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
     -o build/pizza-${GOOS}-${GOARCH}
 
+# Builds for agnostic Linux on amd64 architecture
 build-linux-amd64:
   #!/usr/bin/env sh
 
@@ -74,8 +90,10 @@ build-linux-amd64:
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
+    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
     -o build/pizza-${GOOS}-${GOARCH}
 
+# Builds for agnostic Linux on arm64 architecture
 build-linux-arm64:
   #!/usr/bin/env sh
 
@@ -92,8 +110,10 @@ build-linux-arm64:
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
+    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
     -o build/pizza-${GOOS}-${GOARCH}
 
+# Builds for Windows on amd64 architecture
 build-windows-amd64:
   #!/usr/bin/env sh
 
@@ -110,8 +130,10 @@ build-windows-amd64:
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
+    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
     -o build/pizza-${GOOS}-${GOARCH}
 
+# Builds for Windows on arm64 architecture
 build-windows-arm64:
   #!/usr/bin/env sh
 
@@ -128,16 +150,19 @@ build-windows-arm64:
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
     -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
+    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
     -o build/pizza-${GOOS}-${GOARCH}
 
-# Builds the container and marks it tagged as "dev" locally
+# Builds the Docker container and tags it as "dev"
 build-container:
   docker build \
     --build-arg VERSION="$(git describe --tags --always)" \
     --build-arg SHA="$(git rev-parse HEAD)" \
     --build-arg DATETIME="$(date -u +'%Y-%m-%d %H:%M:%S')" \
+    --build-arg POSTHOG_PUBLIC_API_KEY="${POSTHOG_PUBLIC_API_KEY}" \
     -t pizza:dev .
 
+# Removes build artifacts
 clean:
   rm -rf build/
 
@@ -148,19 +173,20 @@ test: unit-test
 unit-test:
   go test ./...
 
-# Lints the Go code via golangcilint in Docker
+# Lints Go code via golangci-lint within Docker
 lint:
   docker run \
     -t \
     --rm \
     -v "$(pwd)/:/app" \
     -w /app \
-    golangci/golangci-lint:v1.59 \
+    golangci/golangci-lint:v1.60 \
     golangci-lint run -v
 
-# Formats code via builtin go fmt
+# Formats Go code via goimports
 format:
   find . -type f -name "*.go" -exec goimports -local github.com/open-sauced/pizza-cli -w {} \;
 
+# Runs Go code manually through the main.go
 run:
   go run main.go


### PR DESCRIPTION
## Description

This PR does the following:
- Exhumes the posthog reporting including the buildtime variable. The justfile loads the posthog public API key from the new `.env`
  - closes: https://github.com/open-sauced/pizza-cli/issues/125
  - Adds posthog capturing for codeowners generate commands and insight commands
- Introduces a `just help` command to get a list of all commands (and their descriptions)
  - closes: https://github.com/open-sauced/pizza-cli/issues/119
- Upgrades golangci-lint to `golangci-lint:v1.60`

## Steps to QA

1. Build locally
2. For the core engineering team, you can log in and see the events being captured by the CLI

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4