### PR TITLE
fix: Corrects invalid gosec lint error

### DIFF
--- a/justfile
+++ b/justfile
@@ -187,6 +187,19 @@ lint:
 format:
   find . -type f -name "*.go" -exec goimports -local github.com/open-sauced/pizza-cli -w {} \;
 
+# Installs the dev tools for working with this project. Requires "go", "just", and "docker"
+install-dev-tools:
+  #!/usr/bin/env sh
+
+  go install golang.org/x/tools/cmd/goimports@latest
+
 # Runs Go code manually through the main.go
 run:
   go run main.go
+
+# Re-generates the docs from the cobra command tree
+gen-docs:
+  go run main.go docs ./docs/
+
+# Runs all the dev tasks (like formatting, linting, building, etc.)
+dev: format lint test build-all

--- a/pkg/utils/root.go
+++ b/pkg/utils/root.go
@@ -20,6 +20,8 @@ func SetupRootCommand(rootCmd *cobra.Command) {
 
 // Uses the users terminal size or width of 80 if cannot determine users width
 func wrappedFlagUsages(cmd *pflag.FlagSet) string {
+	// converts the uintptr to the system file descriptor integer
+	//nolint:gosec
 	fd := int(os.Stdout.Fd())
 	width := 80
 


### PR DESCRIPTION
## Description

- Ignores an invalid `gosec` lint error
- Adds a few nice to have `just` commands:
  - `just gen-docs` re-generates the docs into the `./docs/` directory
  - `just dev` runs all the common dev commands
  - `just install-dev-tools` installs the necessary, third party dev tools (right now, just `goimports`

## Related Tickets & Documents

Followup to #143 and #148 

## Steps to QA

Run the additional `just` commands

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4