### PR TITLE
fix: skip interactive steps in generate codeowners with --tty-disable flag

### DIFF
--- a/cmd/generate/codeowners/codeowners.go
+++ b/cmd/generate/codeowners/codeowners.go
@@ -171,6 +171,11 @@ func run(opts *Options, cmd *cobra.Command) error {
 	opts.logger.V(logging.LogInfo).Style(0, colors.FgGreen).Infof("Finished generating file: %s\n", outputPath)
 	opts.telemetry.CaptureCodeownersGenerate()
 
+	// ignore the interactive prompts for CI/CD environments
+	if opts.tty {
+		return nil
+	}
+
 	// 1. Ask if they want to add users to a list
 	var input string
 	fmt.Print("Do you want to add these codeowners to an OpenSauced Contributor Insight? (y/n): ")


### PR DESCRIPTION
## Description

Now if the `--tty-disable` flag is passed to generate a codeowners, the interactive steps are skipped.

~There are currently no tests for codeowners.go. I'm going to look at adding some.~ (punting for now as mentioned below)

## Related Tickets & Documents

Closes #154

## Mobile & Desktop Screenshots/Recordings

![CleanShot 2024-09-06 at 17 23 11](https://github.com/user-attachments/assets/8a4fd88a-5b84-441c-94ed-c37f70c8fcaa)

## Steps to QA

1. Run `just build`
2. Run `./build/pizza generate codeowners --tty-disable`
3. Notice the command runs and skips the interactive steps.
4. Run `./build/pizza generate codeowners`
5. Notice the command runs and does not skip the interactive steps.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/lptIayuGHV9Utu3iTv/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
