### PR TITLE
feat: Posthog events bootstrapping

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -35,15 +35,16 @@ func NewLoginCommand() *cobra.Command {
 			disableTelem, _ := cmd.Flags().GetBool(constants.FlagNameTelemetry)
 
 			opts.telemetry = utils.NewPosthogCliClient(!disableTelem)
-			defer opts.telemetry.Done()
 
 			username, err := run()
 
 			if err != nil {
-				opts.telemetry.CaptureFailedLogin()
+				_ = opts.telemetry.CaptureFailedLogin()
 			} else {
-				opts.telemetry.CaptureLogin(username)
+				_ = opts.telemetry.CaptureLogin(username)
 			}
+
+			_ = opts.telemetry.Done()
 
 			return err
 		},

--- a/cmd/insights/contributors.go
+++ b/cmd/insights/contributors.go
@@ -57,7 +57,6 @@ func NewContributorsCommand() *cobra.Command {
 			disableTelem, _ := cmd.Flags().GetBool(constants.FlagNameTelemetry)
 
 			opts.telemetry = utils.NewPosthogCliClient(!disableTelem)
-			defer opts.telemetry.Done()
 
 			endpointURL, _ := cmd.Flags().GetString(constants.FlagNameEndpoint)
 			opts.APIClient = api.NewClient(endpointURL)
@@ -67,10 +66,12 @@ func NewContributorsCommand() *cobra.Command {
 			err := opts.run()
 
 			if err != nil {
-				opts.telemetry.CaptureInsights()
+				_ = opts.telemetry.CaptureInsights()
 			} else {
-				opts.telemetry.CaptureFailedInsights()
+				_ = opts.telemetry.CaptureFailedInsights()
 			}
+
+			_ = opts.telemetry.Done()
 
 			return err
 		},

--- a/cmd/insights/repositories.go
+++ b/cmd/insights/repositories.go
@@ -57,7 +57,6 @@ func NewRepositoriesCommand() *cobra.Command {
 			disableTelem, _ := cmd.Flags().GetBool(constants.FlagNameTelemetry)
 
 			opts.telemetry = utils.NewPosthogCliClient(!disableTelem)
-			defer opts.telemetry.Done()
 
 			endpointURL, _ := cmd.Flags().GetString(constants.FlagNameEndpoint)
 			opts.APIClient = api.NewClient(endpointURL)
@@ -67,10 +66,12 @@ func NewRepositoriesCommand() *cobra.Command {
 			err := opts.run()
 
 			if err != nil {
-				opts.telemetry.CaptureInsights()
+				_ = opts.telemetry.CaptureInsights()
 			} else {
-				opts.telemetry.CaptureFailedInsights()
+				_ = opts.telemetry.CaptureFailedInsights()
 			}
+
+			_ = opts.telemetry.Done()
 
 			return err
 		},

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cli/browser v1.3.0
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/jpmcb/gopherlogs v0.2.0
-	github.com/posthog/posthog-go v1.2.19
+	github.com/posthog/posthog-go v1.2.21
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
@@ -40,6 +40,7 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.5.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/google/uuid v1.6.0
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
@@ -103,6 +105,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posthog/posthog-go v1.2.19 h1:0udGG2do4LjOzE0D/ik7S3uM2wwFKwzSqswBfdcQ1y4=
 github.com/posthog/posthog-go v1.2.19/go.mod h1:uYC2l1Yktc8E+9FAHJ9QZG4vQf/NHJPD800Hsm7DzoM=
+github.com/posthog/posthog-go v1.2.21 h1:p2ea0l+Qwtk+VC2LCAI87Dz36vwj9i+QHw5s6CpRikA=
+github.com/posthog/posthog-go v1.2.21/go.mod h1:uYC2l1Yktc8E+9FAHJ9QZG4vQf/NHJPD800Hsm7DzoM=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/justfile
+++ b/justfile
@@ -203,3 +203,19 @@ gen-docs:
 
 # Runs all the dev tasks (like formatting, linting, building, etc.)
 dev: format lint test build-all
+
+# Calls the various Posthog capture events to add the Insights to the database
+bootstrap-telemetry:
+  #!/usr/bin/env sh
+  echo "Building telemetry-oneshot"
+
+  go build \
+    -tags telemetry \
+    -ldflags="-s -w" \
+    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
+    -o build/telemetry-oneshot \
+    telemetry.go
+
+  ./build/telemetry-oneshot
+
+  rm ./build/telemetry-oneshot

--- a/pkg/utils/posthog.go
+++ b/pkg/utils/posthog.go
@@ -17,7 +17,7 @@ type PosthogCliClient struct {
 	// client is the Posthog Go client
 	client posthog.Client
 
-	// activated denotes if the user has turned off telemetry
+	// activated denotes if the user has enabled or disabled telemetry
 	activated bool
 
 	// uniqueID is the user's unique, anonymous identifier

--- a/pkg/utils/posthog.go
+++ b/pkg/utils/posthog.go
@@ -1,19 +1,27 @@
 package utils
 
 import (
+	"fmt"
+
 	"github.com/posthog/posthog-go"
 )
 
 var (
 	writeOnlyPublicPosthogKey = "dev"
-	posthogEndpoint           = "https://app.posthog.com"
+	posthogEndpoint           = "https://us.i.posthog.com"
 )
 
 // PosthogCliClient is a wrapper around the posthog-go client and is used as a
 // API entrypoint for sending OpenSauced telemetry data for CLI commands
 type PosthogCliClient struct {
-	client    posthog.Client
+	// client is the Posthog Go client
+	client posthog.Client
+
+	// activated denotes if the user has turned off telemetry
 	activated bool
+
+	// uniqueID is the user's unique, anonymous identifier
+	uniqueID string
 }
 
 // NewPosthogCliClient returns a PosthogCliClient which can be used to capture
@@ -32,120 +40,142 @@ func NewPosthogCliClient(activated bool) *PosthogCliClient {
 		panic(err)
 	}
 
+	uniqueID, err := getOrCreateUniqueID()
+	if err != nil {
+		fmt.Printf("could not build anonymous telemetry client: %s\n", err)
+	}
+
 	return &PosthogCliClient{
 		client:    client,
 		activated: activated,
+		uniqueID:  uniqueID,
 	}
 }
 
 // Done should always be called in order to flush the Posthog buffers before
 // the CLI exits to ensure all events are accurately captured.
-//
-//nolint:errcheck
-func (p *PosthogCliClient) Done() {
-	p.client.Close()
+func (p *PosthogCliClient) Done() error {
+	return p.client.Close()
 }
 
 // CaptureLogin gathers telemetry on users who log into OpenSauced via the CLI
-//
-//nolint:errcheck
-func (p *PosthogCliClient) CaptureLogin(username string) {
+func (p *PosthogCliClient) CaptureLogin(username string) error {
 	if p.activated {
-		p.client.Enqueue(posthog.Capture{
+		return p.client.Enqueue(posthog.Capture{
 			DistinctId: username,
-			Event:      "cli_user logged in",
+			Event:      "pizza_cli_user_logged_in",
 		})
 	}
+
+	return nil
 }
 
 // CaptureFailedLogin gathers telemetry on failed logins via the CLI
-//
-//nolint:errcheck
-func (p *PosthogCliClient) CaptureFailedLogin() {
+func (p *PosthogCliClient) CaptureFailedLogin() error {
 	if p.activated {
-		p.client.Enqueue(posthog.Capture{
-			DistinctId: "login-failures",
-			Event:      "cli_user failed log in",
+		return p.client.Enqueue(posthog.Capture{
+			DistinctId: p.uniqueID,
+			Event:      "pizza_cli_user_failed_log_in",
 		})
 	}
+
+	return nil
 }
 
-//nolint:errcheck
-func (p *PosthogCliClient) CaptureCodeownersGenerate() {
+// CaptureCodeownersGenerate gathers telemetry on successful codeowners generation
+func (p *PosthogCliClient) CaptureCodeownersGenerate() error {
 	if p.activated {
-		p.client.Enqueue(posthog.Capture{
-			DistinctId: "codeowners-generated",
-			Event:      "cli generated codeowners",
+		return p.client.Enqueue(posthog.Capture{
+			DistinctId: p.uniqueID,
+			Event:      "pizza_cli_generated_codeowners",
 		})
 	}
+
+	return nil
 }
 
-//nolint:errcheck
-func (p *PosthogCliClient) CaptureFailedCodeownersGenerate() {
+// CaptureFailedCodeownersGenerate gathers telemetry on failed codeowners generation
+func (p *PosthogCliClient) CaptureFailedCodeownersGenerate() error {
 	if p.activated {
-		p.client.Enqueue(posthog.Capture{
-			DistinctId: "failed-codeowners-generated",
-			Event:      "cli failed to generate codeowners",
+		return p.client.Enqueue(posthog.Capture{
+			DistinctId: p.uniqueID,
+			Event:      "pizza_cli_failed_to_generate_codeowners",
 		})
 	}
+
+	return nil
 }
 
-//nolint:errcheck
-func (p *PosthogCliClient) CaptureCodeownersGenerateAuth(username string) {
+// CaptureCodeownersGenerateAuth gathers telemetry on successful auth flows during codeowners generation
+func (p *PosthogCliClient) CaptureCodeownersGenerateAuth(username string) error {
 	if p.activated {
-		p.client.Enqueue(posthog.Capture{
+		return p.client.Enqueue(posthog.Capture{
 			DistinctId: username,
-			Event:      "user authenticated during generate codeowners flow",
+			Event:      "pizza_cli_user_authenticated_during_generate_codeowners_flow",
 		})
 	}
+
+	return nil
 }
 
-//nolint:errcheck
-func (p *PosthogCliClient) CaptureFailedCodeownersGenerateAuth() {
+// CaptureFailedCodeownersGenerateAuth gathers telemetry on failed auth flows during codeowners generations
+func (p *PosthogCliClient) CaptureFailedCodeownersGenerateAuth() error {
 	if p.activated {
-		p.client.Enqueue(posthog.Capture{
-			DistinctId: "codeowners-generate-auth-failed",
-			Event:      "user failed to authenticate during generate codeowners flow",
+		return p.client.Enqueue(posthog.Capture{
+			DistinctId: p.uniqueID,
+			Event:      "pizza_cli_user_failed_to_authenticate_during_generate_codeowners_flow",
 		})
 	}
+
+	return nil
 }
 
-//nolint:errcheck
-func (p *PosthogCliClient) CaptureCodeownersGenerateContributorInsight() {
+// CaptureCodeownersGenerateContributorInsight gathers telemetry on successful
+// Contributor Insights creation/update during codeowners generation
+func (p *PosthogCliClient) CaptureCodeownersGenerateContributorInsight() error {
 	if p.activated {
-		p.client.Enqueue(posthog.Capture{
-			DistinctId: "codeowners-generate-contributor-insight",
-			Event:      "cli created/updated contributor list for user",
+		return p.client.Enqueue(posthog.Capture{
+			DistinctId: p.uniqueID,
+			Event:      "pizza_cli_created_updated_contributor_list",
 		})
 	}
+
+	return nil
 }
 
-//nolint:errcheck
-func (p *PosthogCliClient) CaptureFailedCodeownersGenerateContributorInsight() {
+// CaptureFailedCodeownersGenerateContributorInsight gathers telemetry on failed
+// Contributor Insights during codeowners generation
+func (p *PosthogCliClient) CaptureFailedCodeownersGenerateContributorInsight() error {
 	if p.activated {
-		p.client.Enqueue(posthog.Capture{
-			DistinctId: "failed-codeowners-generation-contributor-insight",
-			Event:      "cli failed to create/update contributor insight for user",
+		return p.client.Enqueue(posthog.Capture{
+			DistinctId: p.uniqueID,
+			Event:      "pizza_cli_failed_to_create_update_contributor_insight_for_user",
 		})
 	}
+
+	return nil
 }
 
-//nolint:errcheck
-func (p *PosthogCliClient) CaptureInsights() {
+// CaptureInsights gathers telemetry on successful Insights command runs
+func (p *PosthogCliClient) CaptureInsights() error {
 	if p.activated {
-		p.client.Enqueue(posthog.Capture{
-			DistinctId: "insights",
-			Event:      "cli called insights command",
+		return p.client.Enqueue(posthog.Capture{
+			DistinctId: p.uniqueID,
+			Event:      "pizza_cli_called_insights_command",
 		})
 	}
+
+	return nil
 }
 
-//nolint:errcheck
-func (p *PosthogCliClient) CaptureFailedInsights() {
+// CaptureFailedInsights gathers telemetry on failed Insights command runs
+func (p *PosthogCliClient) CaptureFailedInsights() error {
 	if p.activated {
-		p.client.Enqueue(posthog.Capture{
-			DistinctId: "failed-insight",
-			Event:      "cli failed to call insights command",
+		return p.client.Enqueue(posthog.Capture{
+			DistinctId: p.uniqueID,
+			Event:      "pizza_cli_failed_to_call_insights_command",
 		})
 	}
+
+	return nil
 }

--- a/pkg/utils/telemetry.go
+++ b/pkg/utils/telemetry.go
@@ -1,0 +1,66 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+)
+
+var telemetryFilePath = filepath.Join(os.Getenv("HOME"), ".pizza-cli", "telemetry.json")
+
+// userTelemetryConfig is the config for the user's anonymous telemetry data
+type userTelemetryConfig struct {
+	ID string `json:"id"`
+}
+
+// getOrCreateUniqueID reads the telemetry.json file to fetch the user's anonymous, unique ID.
+// In case of error (i.e., if the file doesn't exist or is invalid) it generates
+// a new UUID and stores it in the telemetry.json file
+func getOrCreateUniqueID() (string, error) {
+	if _, err := os.Stat(telemetryFilePath); os.IsNotExist(err) {
+		return createTelemetryUUID()
+	}
+
+	data, err := os.ReadFile(telemetryFilePath)
+	if err != nil {
+		return createTelemetryUUID()
+	}
+
+	// Try parsing the telemetry file
+	var teleData userTelemetryConfig
+	err = json.Unmarshal(data, &teleData)
+	if err != nil || teleData.ID == "" {
+		return createTelemetryUUID()
+	}
+
+	return teleData.ID, nil
+}
+
+// createTelemetryUUID generates a new UUID and writes it to the user's telemetry.json file
+func createTelemetryUUID() (string, error) {
+	newUUID := uuid.New().String()
+
+	teleData := userTelemetryConfig{
+		ID: newUUID,
+	}
+
+	data, err := json.Marshal(teleData)
+	if err != nil {
+		return "", fmt.Errorf("error creating telemetry data: %w", err)
+	}
+
+	err = os.MkdirAll(filepath.Dir(telemetryFilePath), 0755)
+	if err != nil {
+		return "", fmt.Errorf("error creating directory for telemetry file: %w", err)
+	}
+
+	err = os.WriteFile(telemetryFilePath, data, 0600)
+	if err != nil {
+		return "", fmt.Errorf("error writing telemetry file: %w", err)
+	}
+
+	return newUUID, nil
+}

--- a/telemetry.go
+++ b/telemetry.go
@@ -1,0 +1,75 @@
+//go:build telemetry
+// +build telemetry
+
+package main
+
+import "github.com/open-sauced/pizza-cli/pkg/utils"
+
+// This alternate main is used as a one-shot for bootstrapping Posthog events:
+// the various events called herein do not exist in Posthog's datalake until the
+// event has landed.
+//
+// Therefore, this is useful for when there are new events for Posthog that need
+// a dashboard bootstrapped for them.
+
+func main() {
+	println("Started bootstrapping Posthog events")
+	client := utils.NewPosthogCliClient(true)
+
+	err := client.CaptureLogin("test-user")
+	if err != nil {
+		panic(err)
+	}
+
+	err = client.CaptureFailedLogin()
+	if err != nil {
+		panic(err)
+	}
+
+	err = client.CaptureCodeownersGenerate()
+	if err != nil {
+		panic(err)
+	}
+
+	err = client.CaptureFailedCodeownersGenerate()
+	if err != nil {
+		panic(err)
+	}
+
+	err = client.CaptureCodeownersGenerateAuth("test-user")
+	if err != nil {
+		panic(err)
+	}
+
+	err = client.CaptureFailedCodeownersGenerateAuth()
+	if err != nil {
+		panic(err)
+	}
+
+	err = client.CaptureCodeownersGenerateContributorInsight()
+	if err != nil {
+		panic(err)
+	}
+
+	err = client.CaptureFailedCodeownersGenerateContributorInsight()
+	if err != nil {
+		panic(err)
+	}
+
+	err = client.CaptureInsights()
+	if err != nil {
+		panic(err)
+	}
+
+	err = client.CaptureFailedInsights()
+	if err != nil {
+		panic(err)
+	}
+
+	err = client.Done()
+	if err != nil {
+		panic(err)
+	}
+
+	println("Done bootstrapping Posthog events")
+}


### PR DESCRIPTION
## Description

This PR does a few things:
- Upgrades github.com/posthog/posthog-go up to v1.2.21
- Implements anonoymous user tracking with UUIDs as the `DistinctID` for events. This ID is stored locally in `~/.pizza-cli/telemetry.json`. Users can always delete this file or entirely disable telemetry via the global `--disable-telemetry` flag
- Implements a sidechain Go program (build and runable via Go's `-tags telemetry` flag) which bootstraps the events for Posthog. Why is this needed? You can't really make a dashboard in Posthog until an event has landed in the data lake. This simplifies this process by sending the events all at once to Posthog to make dashboard creation easy
- Updates the Posthog endpoint to `https://us.i.posthog.com`
- Adds error handling for each of the capture Posthog functions (which is generally ignored in the actual flow but captured in the bootstrapping Go program)

## Related Tickets & Documents

Followup to #147 

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4