### PR TITLE
fix: docs generation runs outside of build matrix now

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Generate token
+      - name: "Generate token"
         id: generate_token
         uses: tibdex/github-app-token@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,7 +92,7 @@ jobs:
         run: ./scripts/generate-docs.sh
         env:
           GITHUB_REF: ${{ github.ref }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
   build:
     name: Build and publish artifacts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,10 +59,46 @@ jobs:
           NPM_PACKAGE_ROOT: "npm"
           SKIP_DOCKER_PUBLISH: true
 
+  docs:
+    name: Update documentation
+    needs:
+      - release
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.OS_GITHUB_APP_ID }}
+          private_key: ${{ secrets.OS_GITHUB_APP_PRIVATE_KEY }}
+
+      - name: "☁️ checkout repository"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: "🐹 Setup Go"
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.x
+
+      - name: "🤲 Setup Just"
+        uses: extractions/setup-just@v2
+
+      - name: "📗 Generate Documentation"
+        run: ./scripts/generate-docs.sh
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          GH_TOKEN: ${{ github.token }}
+
   build:
     name: Build and publish artifacts
     needs:
       - release
+      - docs
     if: needs.release.outputs.release-tag != ''
     runs-on: ubuntu-latest
     permissions:
@@ -84,11 +120,6 @@ jobs:
 
     - name: "🤲 Setup Just"
       uses: extractions/setup-just@v2
-
-    - name: "📗 Generate Documentation"
-      run: ./scripts/generate-docs.sh
-      env:
-        GITHUB_REF: ${{ github.ref }}
 
     - name: "🔧 Build all and upload artifacts to release"
       env:


### PR DESCRIPTION
## Description

This continues in the work in #162, however, now the docs is a separate job so it doesn't repeat itself in the build matrix job.

## Related Tickets & Documents

Fixes #161

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA

We can try on beta again. This is a little more difficult to test on a test repo.

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
