### PR TITLE
fix: Don't overwrite `ldflags` in justfile builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -155,3 +155,6 @@ jobs:
         with:
           tags: ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:${{ needs.release.outputs.release-tag }}
           push: true
+          build-args:
+            - VERSION=${{ needs.release.outputs.release-tag }}
+            - POSTHOG_PUBLIC_API_KEY=${{ vars.POSTHOG_WRITE_PUBLIC_KEY }}

--- a/justfile
+++ b/justfile
@@ -11,14 +11,15 @@ build:
   echo "Building for local arch"
 
   export VERSION="${RELEASE_TAG_VERSION:-dev}"
-  export DATETIME=$(date -u +"%Y-%m-%d %H:%M:%S")
+  export DATETIME=$(date -u +"%Y-%m-%d-%H:%M:%S")
+  export SHA=$(git rev-parse HEAD)
 
   go build \
-    -ldflags="-s -w" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
+    -ldflags="-s -w \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=${SHA}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
     -o build/pizza
 
 # Builds and installs the go binary for the local architecture. WARNING: requires sudo access
@@ -40,17 +41,18 @@ build-darwin-amd64:
   echo "Building darwin amd64"
 
   export VERSION="${RELEASE_TAG_VERSION:-dev}"
-  export DATETIME=$(date -u +"%Y-%m-%d %H:%M:%S")
+  export DATETIME=$(date -u +"%Y-%m-%d-%H:%M:%S")
+  export SHA=$(git rev-parse HEAD)
   export CGO_ENABLED=0
   export GOOS="darwin"
   export GOARCH="amd64"
 
   go build \
-    -ldflags="-s -w" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
+    -ldflags="-s -w \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=${SHA}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
     -o build/pizza-${GOOS}-${GOARCH}
 
 # Builds for Darwin linux (i.e., MacOS) on arm64 architecture (i.e. Apple silicon)
@@ -60,17 +62,18 @@ build-darwin-arm64:
   echo "Building darwin arm64"
 
   export VERSION="${RELEASE_TAG_VERSION:-dev}"
-  export DATETIME=$(date -u +"%Y-%m-%d %H:%M:%S")
+  export DATETIME=$(date -u +"%Y-%m-%d-%H:%M:%S")
+  export SHA=$(git rev-parse HEAD)
   export CGO_ENABLED=0
   export GOOS="darwin"
   export GOARCH="arm64"
 
   go build \
-    -ldflags="-s -w" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
+    -ldflags="-s -w \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=${SHA}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
     -o build/pizza-${GOOS}-${GOARCH}
 
 # Builds for agnostic Linux on amd64 architecture
@@ -80,17 +83,18 @@ build-linux-amd64:
   echo "Building linux amd64"
 
   export VERSION="${RELEASE_TAG_VERSION:-dev}"
-  export DATETIME=$(date -u +"%Y-%m-%d %H:%M:%S")
+  export DATETIME=$(date -u +"%Y-%m-%d-%H:%M:%S")
+  export SHA=$(git rev-parse HEAD)
   export CGO_ENABLED=0
   export GOOS="linux"
   export GOARCH="amd64"
 
   go build \
-    -ldflags="-s -w" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
+    -ldflags="-s -w \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=${SHA}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
     -o build/pizza-${GOOS}-${GOARCH}
 
 # Builds for agnostic Linux on arm64 architecture
@@ -100,17 +104,18 @@ build-linux-arm64:
   echo "Building linux arm64"
 
   export VERSION="${RELEASE_TAG_VERSION:-dev}"
-  export DATETIME=$(date -u +"%Y-%m-%d %H:%M:%S")
+  export DATETIME=$(date -u +"%Y-%m-%d-%H:%M:%S")
+  export SHA=$(git rev-parse HEAD)
   export CGO_ENABLED=0
   export GOOS="linux"
   export GOARCH="arm64"
 
   go build \
-    -ldflags="-s -w" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
+    -ldflags="-s -w \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=${SHA}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
     -o build/pizza-${GOOS}-${GOARCH}
 
 # Builds for Windows on amd64 architecture
@@ -120,17 +125,18 @@ build-windows-amd64:
   echo "Building windows amd64"
 
   export VERSION="${RELEASE_TAG_VERSION:-dev}"
-  export DATETIME=$(date -u +"%Y-%m-%d %H:%M:%S")
+  export DATETIME=$(date -u +"%Y-%m-%d-%H:%M:%S")
+  export SHA=$(git rev-parse HEAD)
   export CGO_ENABLED=0
   export GOOS="windows"
   export GOARCH="amd64"
 
   go build \
-    -ldflags="-s -w" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
+    -ldflags="-s -w \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=${SHA}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
     -o build/pizza-${GOOS}-${GOARCH}
 
 # Builds for Windows on arm64 architecture
@@ -140,25 +146,34 @@ build-windows-arm64:
   echo "Building windows arm64"
 
   export VERSION="${RELEASE_TAG_VERSION:-dev}"
-  export DATETIME=$(date -u +"%Y-%m-%d %H:%M:%S")
+  export DATETIME=$(date -u +"%Y-%m-%d-%H:%M:%S")
+  export SHA=$(git rev-parse HEAD)
   export CGO_ENABLED=0
   export GOOS="windows"
   export GOARCH="arm64"
 
   go build \
-    -ldflags="-s -w" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=$(git rev-parse HEAD)'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}'" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
+    -ldflags="-s -w \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Version=${VERSION}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Sha=${SHA}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.Datetime=${DATETIME}' \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
     -o build/pizza-${GOOS}-${GOARCH}
 
 # Builds the Docker container and tags it as "dev"
 build-container:
+  #!/usr/bin/env sh
+
+  echo "Building container"
+
+  export VERSION="${RELEASE_TAG_VERSION:-dev}"
+  export DATETIME=$(date -u +"%Y-%m-%d-%H:%M:%S")
+  export SHA=$(git rev-parse HEAD)
+
   docker build \
-    --build-arg VERSION="$(git describe --tags --always)" \
-    --build-arg SHA="$(git rev-parse HEAD)" \
-    --build-arg DATETIME="$(date -u +'%Y-%m-%d %H:%M:%S')" \
+    --build-arg VERSION="${VERSION}" \
+    --build-arg SHA="${SHA}" \
+    --build-arg DATETIME="${DATETIME}" \
     --build-arg POSTHOG_PUBLIC_API_KEY="${POSTHOG_PUBLIC_API_KEY}" \
     -t pizza:dev .
 
@@ -211,8 +226,8 @@ bootstrap-telemetry:
 
   go build \
     -tags telemetry \
-    -ldflags="-s -w" \
-    -ldflags="-X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
+    -ldflags="-s -w \
+    -X 'github.com/open-sauced/pizza-cli/pkg/utils.writeOnlyPublicPosthogKey=${POSTHOG_PUBLIC_API_KEY}'" \
     -o build/telemetry-oneshot \
     telemetry.go
 


### PR DESCRIPTION
## Description

There was a small error that was causing the ldflags to get overwritten (one after another). More or less a `go build` command error.

This also adds missing build-args for the docker container in the GitHub action. Date and sha might be abit more tricky to get into that action, but for now, the version is good enough

## Related Tickets & Documents

Closes: https://github.com/open-sauced/pizza-cli/issues/167 (cc @brandonroberts - I ended up going down a rabbit hole on this one, apologies)

## Steps to QA

1. `just build-all`
2. Run `./build/pizza-darwin-arm64 version` and see the right version and sha

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4